### PR TITLE
Separate ruby build dirs

### DIFF
--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -424,15 +424,6 @@ class Compiler
         # enclose_io_memfs.o - 2nd pass
         prepare_work_dir
         prepare_local if @entrance
-        @utils.rm_f('verconf.h')
-        @utils.rm_f('rbconfig.rb')
-        @utils.rm_f('.rbconfig.time')
-        @utils.rm_f('dir.obj')
-        @utils.rm_f('file.obj')
-        @utils.rm_f('io.obj')
-        @utils.rm_f('main.obj')
-        @utils.rm_f('win32/file.obj')
-        @utils.rm_f('win32/win32.obj')
         @utils.rm_f('include/enclose_io.h')
         @utils.rm_f('enclose_io_memfs.c')
         @compile_env['ENCLOSE_IO_RUBYC_1ST_PASS'] = nil
@@ -476,14 +467,6 @@ class Compiler
         # enclose_io_memfs.o - 2nd pass
         prepare_work_dir
         prepare_local if @entrance
-        @utils.rm_f('verconf.h')
-        @utils.rm_f('rbconfig.rb')
-        @utils.rm_f('.rbconfig.time')
-        @utils.rm_f('dir.o')
-        @utils.rm_f('file.o')
-        @utils.rm_f('io.o')
-        @utils.rm_f('main.o')
-        @utils.rm_f('ruby')
         @utils.rm_f('include/enclose_io.h')
         @utils.rm_f('enclose_io_memfs.c')
         @compile_env['ENCLOSE_IO_RUBYC_1ST_PASS'] = nil

--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -446,18 +446,22 @@ class Compiler
           @utils.cp('ruby_static.exe', @options[:output])
         end
       else
+        ruby_configure = File.join(@ruby_dir, "configure")
+
         unless File.exist?(@ruby_build_1)
           @compile_env['ENCLOSE_IO_RUBYC_1ST_PASS'] = '1'
           @compile_env['ENCLOSE_IO_RUBYC_2ND_PASS'] = nil
           # enclose_io_memfs.o - 1st pass
           Dir.chdir(pass_1) do
-            @utils.run(@compile_env, "#{@utils.escape @ruby_dir}/configure \
-                                    --prefix=#{@utils.escape @ruby_build_1} \
-                                    --enable-bundled-libyaml \
-                                    --without-gmp \
-                                    --disable-dtrace \
-                                    --enable-debug-env \
-                                    --disable-install-rdoc")
+            @utils.run(@compile_env,
+                       ruby_configure,
+                       "--prefix", @ruby_build_1,
+                       "--enable-bundled-libyaml",
+                       "--without-gmp",
+                       "--disable-dtrace",
+                       "--enable-debug-env",
+                       "--disable-install-rdoc")
+
             @utils.run(@compile_env, "make #{@options[:make_args]}")
             @utils.run(@compile_env, "make install")
           end
@@ -473,14 +477,19 @@ class Compiler
         @compile_env['ENCLOSE_IO_RUBYC_1ST_PASS'] = nil
         @compile_env['ENCLOSE_IO_RUBYC_2ND_PASS'] = '1'
         Dir.chdir(pass_2) do
-          @utils.run(@compile_env, "#{@utils.escape @ruby_dir}/configure \
-                                  --prefix=#{@utils.escape @ruby_build_2} \
-                                  --enable-bundled-libyaml \
-                                  --without-gmp \
-                                  --disable-dtrace \
-                                  --enable-debug-env \
-                                  --disable-install-rdoc \
-                                  --with-static-linked-ext")
+          baseruby = File.join(@ruby_build_1_bin, "ruby")
+
+          @utils.run(@compile_env,
+                     ruby_configure,
+                     "--prefix", @ruby_build_2,
+                     "--with-baseruby=#{baseruby}",
+                     "--enable-bundled-libyaml",
+                     "--without-gmp",
+                     "--disable-dtrace",
+                     "--enable-debug-env",
+                     "--disable-install-rdoc",
+                     "--with-static-linked-ext")
+
           make_enclose_io_memfs
           make_enclose_io_vars
           @utils.run(@compile_env, "make #{@options[:make_args]}")

--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -458,7 +458,7 @@ class Compiler
                                     --disable-dtrace \
                                     --enable-debug-env \
                                     --disable-install-rdoc")
-            @utils.run(@compile_env, "make #{@options[:make_args]} -j1")
+            @utils.run(@compile_env, "make #{@options[:make_args]}")
             @utils.run(@compile_env, "make install")
           end
           File.open(File.join(@ruby_dir, 'ext', 'Setup'), 'w') do |f|

--- a/lib/compiler/utils.rb
+++ b/lib/compiler/utils.rb
@@ -27,7 +27,20 @@ class Compiler
     end
     
     def run(*args)
-      STDERR.puts "-> Running #{args}" unless @options[:quiet]
+      unless @options[:quiet]
+        message =
+          if Hash === args.first
+            env = args.first
+            env = env.map { |name, value|
+              value = escape(value)
+              [name, value].join("=")
+            }.join(" ")
+            "#{env} #{args[1..-1].join(" ")}"
+          else
+            args
+          end
+        STDERR.puts "-> #{message}"
+      end
       pid = spawn(*args)
       pid, status = Process.wait2(pid)
       raise Error, "Failed running #{args}" unless status.success?

--- a/tests/ruby-compiler
+++ b/tests/ruby-compiler
@@ -21,7 +21,7 @@ def escape(arg)
 end
 
 tmpdir = File.expand_path("rubyc", Dir.tmpdir)
-tmpdir_ruby = File.join(tmpdir, 'ruby')
+tmpdir_ruby = File.join(tmpdir, 'build_pass_2')
 
 Dir.chdir(File.expand_path('../..', __FILE__))
 


### PR DESCRIPTION
This separates all the ruby build stages and build dirs to prevent errors when recompiling ruby on top of itself.

It uses the technique of compiling ruby from outside of its source directory [described here](https://bugs.ruby-lang.org/projects/ruby/wiki/CommitterHowto#What-to-do-after-you-become-a-committer)