### PR TITLE
fix typo in compiler

### DIFF
--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -821,7 +821,7 @@ class Compiler
       if gemspecs.size > 0
         raise "Multiple gemspecs detected" unless 1 == gemspecs.size
 
-        install_from_gemspec gemspec.first, gemfiles
+        install_from_gemspec gemspecs.first, gemfiles
       elsif gemfiles.size > 0
         raise 'Multiple Gemfiles detected' unless 1 == gemfiles.size
 


### PR DESCRIPTION
Using rubyc cloned from master:

```
Traceback (most recent call last):
        6: from /__enclose_io_memfs__/local/bin/rubyc:143:in `<main>'
        5: from /__enclose_io_memfs__/local/lib/compiler.rb:681:in `run!'
        4: from /__enclose_io_memfs__/local/lib/compiler.rb:808:in `prepare_local'
        3: from /__enclose_io_memfs__/local/lib/compiler/utils.rb:86:in `chdir'
        2: from /__enclose_io_memfs__/local/lib/compiler/utils.rb:86:in `chdir'
        1: from /__enclose_io_memfs__/local/lib/compiler/utils.rb:86:in `block in chdir'
/__enclose_io_memfs__/local/lib/compiler.rb:824:in `block in prepare_local': undefined local variable or method `gemspec' for #<Compiler:0x000055fb177aa928> (NameError)
Did you mean?  gemspecs
```
https://github.com/pmq20/ruby-packer/blob/e3d28dc56a9afe31e10639b9ae9afa95ec96300b/lib/compiler.rb#L824

Command used (nothing insane):

```sh
CPPFLAGS=-P /usr/local/bin/rubyc bin/sample -r . -d /tmp -o sample
```
Directory content:

```
drwxrwxr-x 2 dimitri dimitri 3,5K mai   12 12:11 bin
-rw-rw-r-- 1 dimitri dimitri 3,3K mai    8 11:22 gems.locked
-rw-rw-r-- 1 dimitri dimitri 1,4K mai    8 11:22 gems.rb
drwxrwxr-x 3 dimitri dimitri 3,5K mai   12 12:11 lib
-rw-rw-r-- 1 dimitri dimitri 1,9K mai   12 11:50 sample.gemspec
```

See https://github.com/pmq20/ruby-packer/issues/43