### PR TITLE
Added configurable openssl dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ ENTRANCE can be either a file path, or a "x" string as in bundle exec "x".
       -d, --tmpdir=DIR                 The directory for temporary files
       -c, --clean-tmpdir               Cleans temporary files before compiling
           --keep-tmpdir                Keeps all temporary files that were generated last time
+          --openssl-dir                The path to openssl
           --make-args=ARGS             Extra arguments to be passed to make
           --nmake-args=ARGS            Extra arguments to be passed to nmake
           --auto-update-url=URL        Enables auto-update and specifies the URL to get the latest version
@@ -101,6 +102,15 @@ ENTRANCE can be either a file path, or a "x" string as in bundle exec "x".
           --ruby-api-version           Prints the version of the Ruby API and exit
       -h, --help                       Prints this help and exit
 
+### Openssl
+
+rubyc compiles its own version of openssl without any certifications.
+To be able to use ssl with rubyc it should know where to find the certifications.
+
+By default this path is set to `/usr/local/etc/openssl/` but can be overridden using the `--openssl-dir` argument.
+
+Keep in mind that users running your compiled package should have their certifications
+present in this directory as well.
 
 ## Examples
 

--- a/bin/rubyc
+++ b/bin/rubyc
@@ -79,6 +79,10 @@ OptionParser.new do |opts|
     options[:keep_tmpdir] = true
   end
 
+  opts.on("--openssl-dir", "The path to openssl") do |dir|
+    options[:openssl_dir] = dir
+  end
+
   opts.on("--make-args=ARGS", "Extra arguments to be passed to make") do |args|
     options[:make_args] = args
   end

--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -109,6 +109,7 @@ class Compiler
     @options[:output] = File.expand_path(@options[:output])
     @options[:tmpdir] ||= File.expand_path("rubyc", Dir.tmpdir)
     @options[:tmpdir] = File.expand_path(@options[:tmpdir])
+    @options[:openssl_dir] ||= '/usr/local/etc/openssl/'
 
     if @options[:auto_update_url] || @options[:auto_update_base]
       unless @options[:auto_update_url].length > 0 && @options[:auto_update_base].length > 0
@@ -508,7 +509,7 @@ class Compiler
       @utils.run(@compile_env,
                  "./config",
                  "no-shared",
-                 "--openssldir=/etc/ssl",
+                 "--openssldir=#{@options[:openssl_dir]}",
                  "--prefix=#{@local_build}")
       @utils.run(@compile_env, "make #{@options[:make_args]}")
       @utils.run(@compile_env, "make install_sw")


### PR DESCRIPTION
This pull adds a configurable openssl dir to the available arguments.

We want to add this so that users packing a program are able to make https requests from the build and from within the program itself.

The next step could be to add specific trusted CA certificates to the bundle so that end-users running the compiled programs don't have to have the certificates installed on their system.

References #10 