### PR TITLE
Attempt to make rake test run on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
 
+image: Visual Studio 2015
+
 build_script:
 - ps: |
     $ErrorActionPreference="Stop"
@@ -16,7 +18,7 @@ test_script:
 - cmd: |
     dir C:\
 
-    set PATH=C:\Ruby241\bin;C:\projects\usr\bin;%PATH%
+    set PATH=C:\Ruby24-x64\bin;C:\projects\usr\bin;%PATH%
 
     call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64_x86
 
@@ -32,10 +34,13 @@ test_script:
 
     gem --version
 
-    gem install C:\projects\ruby-compiler\ruby\gems\bundler-*.gem --force --local --no-rdoc --no-ri 
+    gem install bundler --no-rdoc --no-ri
 
     where bundle
 
     bundle --version
 
-    ruby tests\ruby-compiler
+    bundle
+
+    bundle exec rake test
+

--- a/lib/compiler/utils.rb
+++ b/lib/compiler/utils.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 Minqi Pan <pmq2001@gmail.com>
-# 
+#
 # This file is part of Ruby Compiler, distributed under the MIT License
 # For full terms see the included LICENSE file
 
@@ -35,10 +35,13 @@ class Compiler
 
     def escape(arg)
       if Gem.win_platform?
-        if arg.include?('"')
-          raise NotImplementedError
+        if arg =~ /^"[^"]*"$/
+          return arg
+        elsif arg && arg.include?('"')
+          raise NotImplementedError, "Cannot escape #{arg} as it contains a double quote"
+        else
+          %Q{"#{arg}"}
         end
-        %Q{"#{arg}"}
       else
         Shellwords.escape(arg)
       end
@@ -86,12 +89,12 @@ class Compiler
       Dir.chdir(path) { yield }
       STDERR.puts "-> cd #{Dir.pwd}" unless @options[:quiet]
     end
-    
+
     def cp(x, y)
       STDERR.puts "-> cp #{x.inspect} #{y.inspect}" unless @options[:quiet]
       FileUtils.cp(x, y)
     end
-    
+
     def cp_r(x, y, options = {})
       STDERR.puts "-> cp -r #{x.inspect} #{y.inspect}" unless @options[:quiet]
       FileUtils.cp_r(x, y, options)
@@ -116,12 +119,12 @@ class Compiler
       STDERR.puts "-> mkdir #{x}" unless @options[:quiet]
       FileUtils.mkdir(x)
     end
-    
+
     def mkdir_p(x)
       STDERR.puts "-> mkdir -p #{x}" unless @options[:quiet]
       FileUtils.mkdir_p(x)
     end
-    
+
     def remove_dynamic_libs(path)
       ['dll', 'dylib', 'so'].each do |extname|
         Dir["#{path}/**/*.#{extname}"].each do |x|

--- a/rakelib/test.rake
+++ b/rakelib/test.rake
@@ -10,10 +10,11 @@ namespace "test" do
   # This does not use Rake::TestTask because rake runs ruby via sh which
   # and can't determine the correct way to run ruby from inside rubyc
   task "unit" do
+    $LOAD_PATH.unshift '.'
     $LOAD_PATH.unshift 'lib'
 
     Rake::FileList["test/unit/test_*.rb"].each do |test|
-      require_relative test
+      require test
     end
 
     Minitest.autorun


### PR DESCRIPTION
This was an attempt to get ruby-packer specs running on Windows on Appveyor. I've fixed up the Ruby issues, but it fails on some c stuff that I am not knowledgeable enough to correct. I hope this is useful for you.

Ruby 2.4.1 no longer exists on Appveyor.