### PR TITLE
bin/rubyc: Fix openssl-dir option

### DIFF
--- a/bin/rubyc
+++ b/bin/rubyc
@@ -72,7 +72,7 @@ OptionParser.new do |opts|
     options[:keep_tmpdir] = true
   end
 
-  opts.on('--openssl-dir', 'The path to openssl') do |dir|
+  opts.on('--openssl-dir=DIR', 'The path to openssl') do |dir|
     options[:openssl_dir] = dir
   end
 


### PR DESCRIPTION
The option definition was missing the parameter. See https://git.io/JJxvD.

Closes #126.