### PR TITLE
Explicitly set the gem path in the local toolchain env

### DIFF
--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -787,6 +787,7 @@ class Compiler
   def local_toolchain_env
     {
       'CI' => 'true',
+      'GEM_PATH' => File.join(@ruby_install, 'lib', 'ruby', 'gems', self.class.ruby_api_version),
       'PATH' => "#{File.join(@ruby_install, 'bin')}:#{ENV['PATH']}",
       'ENCLOSE_IO_USE_ORIGINAL_RUBY' => 'true',
       'ENCLOSE_IO_RUBYC_1ST_PASS' => 'true',

--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -288,6 +288,7 @@ class Compiler
     @utils.chdir(@work_dir_local) do
       log '=> gem env'
       @utils.run local_toolchain_env, @gem, 'env'
+      @utils.run local_toolchain_env, @bundle, 'env'
       @utils.run(local_toolchain_env, @bundle, 'install')
       # detect Rails
       if @utils.run_allow_failures(local_toolchain_env, @bundle, 'show', 'rails').exitstatus.zero?


### PR DESCRIPTION
Resolves the issues I encountered in #122. What I think was happening is that `bundler` was using my local `GEM_PATH` value when building gems for the `rubyc` package. It's deleted in `Compiler#clean_env` but that occurs _after_ bundler is loaded. This causes various issues in different environments resulting in incomplete bundles when packaging with `rubyc`.

I finally tracked this down when I noticed that it wasn't only gems with native extensions that failed, but _any_ gem I had installed at the `--user-install` gem path. When `rubyc` bundled packages, I noticed those gems would be skipped as if they were already installed. Explicitly setting the `GEM_PATH` resolves this for me and _should_ resolve for all environments.

I was also able to reproduce behavior similar to #75 and #123 and I suspect this change will resolve those two issues as well.

The commit to print `bundle env` is optional but I found it useful for my debugging so I left it in.