### PR TITLE
Fix typo on end_with? on compiler.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,9 +10,9 @@ require 'rake/clean'
 task default: %w[test]
 rubyc_deps = FileList[File.expand_path('**/*', __dir__)] - [File.expand_path(((Gem.win_platform? ? 'rubyc.exe' : 'rubyc')), __dir__)]
 
-desc "build #{(Gem.win_platform? ? 'rubyc.exe' : 'rubyc')}"
+desc "build #{Gem.win_platform? ? 'rubyc.exe' : 'rubyc'}"
 file((Gem.win_platform? ? 'rubyc.exe' : 'rubyc') => rubyc_deps) do
-  warn "Rebuilding #{(Gem.win_platform? ? 'rubyc.exe' : 'rubyc')}..."
+  warn "Rebuilding #{Gem.win_platform? ? 'rubyc.exe' : 'rubyc'}..."
 
   # don't include rubyc in rubyc
   rm_f(Gem.win_platform? ? 'rubyc.exe' : 'rubyc')

--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -164,7 +164,7 @@ class Compiler
     @options[:make_args] ||= "-j#{@utils.default_make_j_arg}" unless Gem.win_platform?
     @options[:output] ||= DEFAULT_NAME
     @options[:output] = File.expand_path(@options[:output])
-    @options[:output] += '.exe' if Gem.win_platform? && !@options[:output].ends_with?('.exe')
+    @options[:output] += '.exe' if Gem.win_platform? && !@options[:output].end_with?('.exe')
     @options[:tmpdir] ||= File.expand_path('rubyc', Dir.tmpdir)
     @options[:tmpdir] = File.expand_path(@options[:tmpdir])
     @options[:openssl_dir] ||= '/usr/local/etc/openssl/'

--- a/test/roundtrip/test_rubyc.rb
+++ b/test/roundtrip/test_rubyc.rb
@@ -46,11 +46,11 @@ class TestRoundTrip < Minitest::Test
 
             flunk <<~MESSAGE unless status.success?
               failed to run ruby #{args.join ' '}
-              
+
               -------- <stdout> ----------
               #{stdout.read}
               -------- <stdout> ----------
-              
+
               -------- <stderr> ----------
               #{stderr.read}
               -------- <stderr> ----------
@@ -79,11 +79,11 @@ class TestRoundTrip < Minitest::Test
 
             flunk <<~MESSAGE unless status.success?
               failed to run rubyc #{args.join ' '}
-              
+
               -------- <stdout> ----------
               #{stdout.read}
               -------- <stdout> ----------
-              
+
               -------- <stderr> ----------
               #{stderr.read}
               -------- <stderr> ----------


### PR DESCRIPTION
Fixes error when doing `rubyc.exe app.rb -o bin/ikar.exe`:
```
NoMethodError (undefined method `ends_with?' for "D:/a/ikar/ikar/bin/ikar.exe":String)
Did you mean?  end_with?
```

Also Rubocop was complaining on CI :man_shrugging: so I've made minor corrections to please him (6a87430)...