### PR TITLE
Make the gdbm subproject build on GCC 10

### DIFF
--- a/vendor/gdbm/src/parseopt.c
+++ b/vendor/gdbm/src/parseopt.c
@@ -252,8 +252,8 @@ print_option_descr (const char *descr, size_t lmargin, size_t rmargin)
 }
 
 char *parseopt_program_name;
-char *parseopt_program_doc;
-char *parseopt_program_args;
+extern char *parseopt_program_doc;
+extern char *parseopt_program_args;
 const char *program_bug_address = "<" PACKAGE_BUGREPORT ">";
 void (*parseopt_help_hook) (FILE *stream);
 


### PR DESCRIPTION
Make the gdbm subproject build on GCC 10

Two variables were not declared as extern. This works until GCC 9, due to the common model, but his has been disabled on GCC 10, which therefore requires changes. See https://bugs.gentoo.org/705898.

This is a patch of a vendored library (gdbm). Possibly, the formal solution is to upgrade to a more recent version, however, until that's done, compiling on GCC 10 is something that needs to be handled.

A potential solution is to pass `-fcommon` as CFLAGS down to the makefiles, but I don't know how to do that and if that's possible.

Closes #145.