### PR TITLE
Fix Ruby 2.7 options warning during compilation

### DIFF
--- a/lib/compiler/utils.rb
+++ b/lib/compiler/utils.rb
@@ -90,7 +90,7 @@ class Compiler
 
     def cp_r(from, to, options = {})
       warn "-> cp -r #{from.inspect} #{to.inspect}" unless @options[:quiet]
-      FileUtils.cp_r(from, to, options)
+      FileUtils.cp_r(from, to, **options)
     end
 
     def rm(path)


### PR DESCRIPTION
During compilation, the usual Ruby 2.7 warning is raised:

    lib/compiler/utils.rb:93: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    /path/to/ruby/2.7.0/fileutils.rb:463: warning: The called method `cp_r' is defined here

The (conventional) fix applied is to unpack the keyword arguments hash.