### PR TITLE
Fix build, due to Rubocop error

### DIFF
--- a/test/roundtrip/test_rubyc.rb
+++ b/test/roundtrip/test_rubyc.rb
@@ -30,14 +30,14 @@ class TestRoundTrip < Minitest::Test
 
             Thread.new do
               until (raw_line = stdout.gets).nil?
-                parsed_line = Hash[timestamp: Time.now, line: raw_line.to_s]
+                parsed_line = { timestamp: Time.now, line: raw_line.to_s }
                 $stdout.puts "rubyc's ruby STDOUT: #{parsed_line}"
               end
             end
 
             Thread.new do
               until (raw_line = stderr.gets).nil?
-                parsed_line = Hash[timestamp: Time.now, line: raw_line.to_s]
+                parsed_line = { timestamp: Time.now, line: raw_line.to_s }
                 warn "rubyc's ruby STDERR: #{parsed_line}"
               end
             end


### PR DESCRIPTION
Fixes the error:

```
Offenses:

test/roundtrip/test_rubyc.rb:33:31: C: [Correctable] Style/HashConversion: Prefer literal hash to Hash[key: value, ...].
                parsed_line = Hash[timestamp: Time.now, line: raw_line.to_s]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test/roundtrip/test_rubyc.rb:40:31: C: [Correctable] Style/HashConversion: Prefer literal hash to Hash[key: value, ...].
                parsed_line = Hash[timestamp: Time.now, line: raw_line.to_s]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

11 files inspected, 2 offenses detected, 2 offenses auto-correctable
Error: Process completed with exit code 1.
```

which breaks the build.

Fixes #155.